### PR TITLE
Override xdg-open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Flatpak build files
+build-dir
+.flatpak-builder

--- a/org.jabref.jabref.json
+++ b/org.jabref.jabref.json
@@ -19,7 +19,8 @@
                 "install -D -m0644 org.jabref.jabref.png /app/share/icons/hicolor/128x128/apps/org.jabref.jabref.png",
                 "install -D -m0644 org.jabref.jabref.desktop /app/share/applications/org.jabref.jabref.desktop",
                 "install -D -m0644 org.jabref.jabref.appdata.xml /app/share/metainfo/org.jabref.jabref.appdata.xml",
-                "install -D -m0755 JabRef-launcher /app/bin/JabRef-launcher"
+                "install -D -m0755 JabRef-launcher /app/bin/JabRef-launcher",
+                "gcc xdg-open.c `pkg-config --cflags --libs glib-2.0 gio-2.0 gio-unix-2.0` -o /app/bin/xdg-open"
             ],
             "sources" : [
                 {
@@ -42,6 +43,10 @@
                 {
                     "type": "file",
                     "path": "org.jabref.jabref.png"
+                },
+                {
+                    "type": "file",
+                    "path": "xdg-open.c"
                 }
             ]
         }

--- a/xdg-open.c
+++ b/xdg-open.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <gio/gio.h>
+#include <glib.h>
+
+int main(int argc, char *argv[]) {
+  GFile *f;
+  char *uri;
+  GError *error = NULL;
+  GAppLaunchContext *context;
+  context = g_app_launch_context_new();
+
+  if (argc != 2) {
+    printf("Usage: xdg-open <path>\n");
+    return -1;
+  }
+
+  // printf("%s\n", argv[1]);
+  f = g_file_new_for_commandline_arg (argv[1]);
+  uri = g_file_get_uri (f);
+  g_app_info_launch_default_for_uri(uri, context, &error);
+  return 0;
+}


### PR DESCRIPTION
This PR overrides the xdg-open command to enable the use of the confined `g_app_info_launch_default_for_uri` function.
Is this an acceptable solution in flathub?