### PR TITLE
fix: add gtk2 module to support workaround for issue #5867

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.jabref.jabref.yaml
+++ b/org.jabref.jabref.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Flatpak
 modules:
-  - shared-modules/libcanberra/libcanberra.json
+  - shared-modules/gtk2/gtk2.json
   - name: JabRef
     buildsystem: simple
     build-commands:

--- a/org.jabref.jabref.yaml
+++ b/org.jabref.jabref.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Flatpak
 modules:
+  - shared-modules/libcanberra/libcanberra.json
   - name: JabRef
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Adds the gtk2 module to the Flatpak build script. This enables the ```-Djdk.gtk.version=2``` workaround for issue [#5867](https://github.com/JabRef/jabref/issues/5867). 